### PR TITLE
fix clang detection for qt on mojave

### DIFF
--- a/depends/packages/qt.mk
+++ b/depends/packages/qt.mk
@@ -8,7 +8,7 @@ $(package)_dependencies=openssl zlib
 $(package)_linux_dependencies=freetype fontconfig libxcb libX11 xproto libXext
 $(package)_build_subdir=qtbase
 $(package)_qt_libs=corelib network widgets gui plugins testlib
-$(package)_patches=mac-qmake.conf aarch32-qmake.conf aarch64-qmake.conf mingw-uuidof.patch pidlist_absolute.patch fix-xcb-include-order.patch fix_qt_pkgconfig.patch
+$(package)_patches=fix_qt_configure.patch mac-qmake.conf aarch32-qmake.conf aarch64-qmake.conf mingw-uuidof.patch pidlist_absolute.patch fix-xcb-include-order.patch fix_qt_pkgconfig.patch
 
 $(package)_qttranslations_file_name=qttranslations-$($(package)_suffix)
 $(package)_qttranslations_sha256_hash=3a15aebd523c6d89fb97b2d3df866c94149653a26d27a00aac9b6d3020bc5a1d
@@ -144,6 +144,7 @@ define $(package)_preprocess_cmds
   cp -f qtbase/mkspecs/linux-arm-gnueabi-g++/qplatformdefs.h qtbase/mkspecs/aarch64-linux-gnu/ &&\
   cp -f $($(package)_patch_dir)/aarch64-qmake.conf qtbase/mkspecs/aarch64-linux-gnu/qmake.conf &&\
   patch -p1 < $($(package)_patch_dir)/mingw-uuidof.patch && \
+  patch -p1 < $($(package)_patch_dir)/fix_qt_configure.patch && \
   patch -p1 < $($(package)_patch_dir)/pidlist_absolute.patch && \
   patch -p1 < $($(package)_patch_dir)/fix-xcb-include-order.patch && \
   patch -p1 < $($(package)_patch_dir)/fix_qt_pkgconfig.patch && \

--- a/depends/patches/qt/fix_qt_configure.patch
+++ b/depends/patches/qt/fix_qt_configure.patch
@@ -1,0 +1,11 @@
+--- old/qtbase/configure
++++ new/qtbase/configure
+@@ -2846,7 +2846,7 @@
+         # with the system. We use 'xcrun' to check the clang version that's part of
+         # the Xcode installation.
+         XCRUN=`/usr/bin/xcrun -sdk macosx clang -v 2>&1`
+-        CLANGVERSION=`echo "$XCRUN" | sed -n 's/.*version \([0-9]\).*/\1/p'`
++        CLANGVERSION=`echo "$XCRUN" | sed -n 's/.*version \([0-9]*\).*/\1/p'`
+         expr "$CLANGVERSION" : '[0-9]' > /dev/null || { echo "Unable to determine CLANG version from output of xcrun: $XCRUN" ; exit 2 ; }
+         if [ "$CLANGVERSION" -ge 3 ]; then
+             PLATFORM=macx-clang


### PR DESCRIPTION
you still need to patch qfontengine_coretext.mm using https://codereview.qt-project.org/#/c/224900/
and patch qcocoahelpers using  https://codereview.qt-project.org/#/c/201546/
for it to compile on mojave.

