### PR TITLE
Return masternodes networks addresses in RPC

### DIFF
--- a/src/rpcmasternode.cpp
+++ b/src/rpcmasternode.cpp
@@ -240,16 +240,19 @@ Value masternode(const Array& params, bool fHelp)
 Value listmasternodes(const Array& params, bool fHelp)
 {
     std::string strFilter = "";
+    bool returnNetworkAddress = false;
 
-    if (params.size() == 1) strFilter = params[0].get_str();
+    if (params.size() >= 1) strFilter = params[0].get_str();
+    if (params.size() == 2) returnNetworkAddress = (params[1].get_str() == "true" ? true : false);
 
-    if (fHelp || (params.size() > 1))
+    if (fHelp || (params.size() > 2))
         throw runtime_error(
             "listmasternodes ( \"filter\" )\n"
             "\nGet a ranked list of masternodes\n"
 
             "\nArguments:\n"
             "1. \"filter\"    (string, optional) Filter search text. Partial match by txhash, status, or addr.\n"
+            "2. network     (boolean, optional, default=false) Return the network address of masternodes.\n"
 
             "\nResult:\n"
             "[\n"
@@ -302,6 +305,7 @@ Value listmasternodes(const Array& params, bool fHelp)
 
             obj.push_back(Pair("rank", (strStatus == "ENABLED" ? s.first : 0)));
             obj.push_back(Pair("network", strNetwork));
+            if (returnNetworkAddress) obj.push_back(Pair("networkaddr", mn->addr.ToString()));
             obj.push_back(Pair("txhash", strTxHash));
             obj.push_back(Pair("outidx", (uint64_t)oIdx));
             obj.push_back(Pair("tier", (uint64_t)mn->tier));


### PR DESCRIPTION
Hi,

I need to get all masternodes network address from the JSON-RPC API for a project about the Transcendence blockchain. So I changed the RPC to add this functionality.

Hope this can be added officially.