### PR TITLE
Replace comparison with assignment when checking mn-payments

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -294,7 +294,7 @@ void CMasternodePayments::FillBlockPayee(CMutableTransaction& txNew, int64_t nFe
         int nCount = 0;
         CMasternode* pmn = mnodeman.GetNextMasternodeInQueueForPayment(pindexPrev->nHeight + 1, true, nCount);
         if (pmn != nullptr) {
-            payee == GetScriptForDestination(pmn->pubKeyCollateralAddress.GetID());
+            payee = GetScriptForDestination(pmn->pubKeyCollateralAddress.GetID());
         }
         else {
             CMasternode* winningNode = mnodeman.GetCurrentMasterNode(1);
@@ -786,7 +786,7 @@ bool CMasternodePayments::ValidateMasternodeWinner(const CTxOut& mnPaymentOut, i
 
         CMasternode* pmn = mnodeman.GetNextMasternodeInQueueForPayment(nBlockHeight, true, nCount);
         if (pmn != nullptr) {
-            payee == GetScriptForDestination(pmn->pubKeyCollateralAddress.GetID());
+            payee = GetScriptForDestination(pmn->pubKeyCollateralAddress.GetID());
         }
     }
 


### PR DESCRIPTION
Hello TELOS-Team,

your latest patches include a patch I wrote yesterday and showed @phoenixkonsole on Discord (see: [Screenshot](https://skyportal.xyz/rACHqOTlu4Q6TWg8RVP1SaQRjjjYr6oZx3W_F0GBJT2MMQ)). Unfortunately at this stage I had a logical error on the patch that wasn't recognized by your devs and not communicated by me to you.

Please review and merge the attached patch as it fixes this issue.