### PR TITLE
Make sure masternode-assets are synced before checking mn-payments

### DIFF
--- a/src/masternode-payments.cpp
+++ b/src/masternode-payments.cpp
@@ -779,6 +779,11 @@ bool CMasternodePayments::ProcessBlock(int nBlockHeight)
 
 bool CMasternodePayments::ValidateMasternodeWinner(const CTxOut& mnPaymentOut, int nBlockHeight)
 {
+    if (!masternodeSync.IsSynced ()) {
+        LogPrint ("mnpayments", "Client not synced, skipping block payee checks\n");
+        return true;
+    }
+    
     int nCount = 0;
     CScript payee;
     if (!masternodePayments.GetBlockPayee(nBlockHeight, payee)) {


### PR DESCRIPTION
Hello TELOS-Team,

unfortunately intial sync for onboarding clients will break because masternode-assets aren't synced. This may be mitigated by disabling the check temporarily until all required assets were synced.