### PR TITLE
Remove ValidateMasternodeWinner in favour of IsTransactionValid

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4004,16 +4004,6 @@ bool CheckBlock(const CBlock& block, CValidationState& state, bool fCheckPOW, bo
         }
     }
         
-    // Check masternode payments
-    if (nHeight > GetSporkValue(SPORK_17_MASTERNODE_PAYMENT_CHECK) && block.IsProofOfStake()) {
-        const CTransaction& tx = block.vtx[1];
-        const unsigned int outs = tx.vout.size();
-        if (outs < 3)
-            return state.DoS(100, error("CheckBlock() : no payment for masternode found"));
-        if (!masternodePayments.ValidateMasternodeWinner(tx.vout[outs-1], nHeight))
-            return state.DoS(100, error("CheckBlock() : wrong masternode address"));
-    }
-
     // Check transactions
     bool fZerocoinActive = true;
     vector<CBigNum> vBlockSerials;

--- a/src/masternode-payments.h
+++ b/src/masternode-payments.h
@@ -257,8 +257,6 @@ public:
     bool AddWinningMasternode(CMasternodePaymentWinner& winner);
     bool ProcessBlock(int nBlockHeight);
 
-    bool ValidateMasternodeWinner(const CTxOut& mnPaymentOut, int nBlockHeight);
-
     void Sync(CNode* node, int nCountNeeded);
     void CleanPaymentList();
     int LastPayment(CMasternode& mn);


### PR DESCRIPTION
Hello Telos-Team,

I know this PR will be a bit hard as you have spent much work for `CMasternodePayments::ValidateMasternodeWinner()` so far, but there is already such functionality on the source-code that just have to used the right way.

This PR removes `CMasternodePayments::ValidateMasternodeWinner()` from the code and re-arms the `CMasternodePayments::IsTransactionValid()`-Check with your `SPORK_17_MASTERNODE_PAYMENT_CHECK`-Spork.

Just like `ValidateMasternodeWinner()` assures `IsTransactionValid()` that there is a masternode-payment on the stake-transaction and has the right value spent. But in contrast to your implementation it is a bit more vague on the masternode that has to be paid. Your implementation requires that one specific masternode is paid which implies that the masternode-assets have to be the same on every node validating this transaction. As the number of masternodes grows and the synchronization-process is a bit laggy this is something that cannot be guaranteed and therefore should be avoided. `IsTransactionValid` adds a bit fuzz and allows a wider set of masternodes to be paid and therefore is likely to fail less. The function is taken from PIVX-upstream, used by most other masternode-coins and can be assumed to be safe - at least it's safe to assume that the payee is a valid masternode.

I'm looking forward for your feedback!

P.S.: It would be better to have this done via the already present but unused spork-key-mechanism (see `SPORK_8_MASTERNODE_PAYMENT_ENFORCEMENT`), but for the moment this PR is more like the update you intended first.